### PR TITLE
Use member type query controller

### DIFF
--- a/lib/helpers/MemberTypeApiHelper.ts
+++ b/lib/helpers/MemberTypeApiHelper.ts
@@ -9,7 +9,7 @@ export class MemberTypeApiHelper{
   }
   
   async ensureNameNotExists(name: string) {
-    const response = await this.api.get(this.api.baseUrl + '/umbraco/backoffice/UmbracoApi/MemberType/GetAllTypes');
+    const response = await this.api.get(this.api.baseUrl + '/umbraco/backoffice/UmbracoApi/MemberTypeQuery/GetAllTypes');
     const searchBody = await JsonHelper.getBody(response);
 
     if(searchBody.length <= 0){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco/playwright-testhelpers",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Test helpers for making playwright tests for Umbraco solutions",
   "main": "dist/lib/index.js",
   "files": ["dist/**/*"],


### PR DESCRIPTION
For v11 the `/umbraco/backoffice/UmbracoApi/MemberType/GetAllTypes` endpoint no longer exists, as it has been moved to `/umbraco/backoffice/UmbracoApi/MemberTypeQuery/GetAllTypes`