### PR TITLE
Actually wait for content

### DIFF
--- a/lib/helpers/ContentApiHelper.ts
+++ b/lib/helpers/ContentApiHelper.ts
@@ -72,8 +72,9 @@ export class ContentApiHelper {
       if( body === expectedContent){
         return true
       }
+
+      await this.api.page.waitForTimeout(5000);
     }
-    await this.api.page.waitForTimeout(5000);
 
     return false;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco/playwright-testhelpers",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Test helpers for making playwright tests for Umbraco solutions",
   "main": "dist/lib/index.js",
   "files": ["dist/**/*"],


### PR DESCRIPTION
- Moved the timeout into the for loop so we actually wait 5 seconds before each try
- Added logging so you can see what is wrong, when the expect fails