### PR TITLE
Switched umbracoApi with this.api

### DIFF
--- a/lib/helpers/ContentApiHelper.ts
+++ b/lib/helpers/ContentApiHelper.ts
@@ -146,18 +146,18 @@ export class ContentApiHelper {
     await this.api.post(this.api.baseUrl + '/umbraco/backoffice/umbracoApi/media/EmptyRecycleBin');
   }
 
-  async createDefaultContentWithABlockGridEditor(umbracoApi, element, dataType, document: boolean) {
+  async createDefaultContentWithABlockGridEditor(element, dataType, document: boolean) {
     const documentName = 'DocumentTest';
     const blockGridName = 'BlockGridTest';
     const documentAlias = AliasHelper.toAlias(documentName);
     const blockGridAlias = AliasHelper.toAlias(blockGridName);
 
     if (element != null && dataType == null) {
-      await this.api.documentTypes.createDefaultDocumentWithBlockGridEditor(umbracoApi, element, null);
+      await this.api.documentTypes.createDefaultDocumentWithBlockGridEditor(element, null);
     } else if (element == null) {
-      element = await this.api.documentTypes.createDefaultDocumentWithBlockGridEditor(umbracoApi, null, null);
+      element = await this.api.documentTypes.createDefaultDocumentWithBlockGridEditor(null, null);
     } else if (!document) {
-      await this.api.documentTypes.createDefaultDocumentWithBlockGridEditor(umbracoApi, element, dataType);
+      await this.api.documentTypes.createDefaultDocumentWithBlockGridEditor(element, dataType);
     }
     const rootContentNode = new ContentBuilder()
       .withContentTypeAlias(documentAlias)
@@ -179,7 +179,7 @@ export class ContentApiHelper {
         .done()
       .done()
       .build();
-    await umbracoApi.content.save(rootContentNode);
+    await this.api.content.save(rootContentNode);
     return element;
   }
 

--- a/lib/helpers/DatatypeApiHelper.ts
+++ b/lib/helpers/DatatypeApiHelper.ts
@@ -44,7 +44,7 @@ export class DatatypeApiHelper {
     return false;
   }
 
-  async createDefaultBlockGrid(umbracoApi, blockGridName, element, label = "") {
+  async createDefaultBlockGrid(blockGridName, element, label = "") {
     const dataTypeBlockGrid = new BlockGridDataTypeBuilder()
       .withName(blockGridName)
       .addBlock()
@@ -53,10 +53,10 @@ export class DatatypeApiHelper {
         .withLabel(label)
       .done()
       .build();
-    return await umbracoApi.dataTypes.save(dataTypeBlockGrid);
+    return await this.api.dataTypes.save(dataTypeBlockGrid);
   }
 
-  async createBlockGridDataTypeWithArea(umbracoApi,elementParent, elementChild, blockGridName, blockArea){
+  async createBlockGridDataTypeWithArea(elementParent, elementChild, blockGridName, blockArea){
 
     const dataTypeBlockGrid = new BlockGridDataTypeBuilder()
       .withName(blockGridName)
@@ -70,6 +70,6 @@ export class DatatypeApiHelper {
         .done()
       .done()
       .build();
-    return await umbracoApi.dataTypes.save(dataTypeBlockGrid);
+    return await this.api.dataTypes.save(dataTypeBlockGrid);
   }
 }

--- a/lib/helpers/DocumentTypeApiHelper.ts
+++ b/lib/helpers/DocumentTypeApiHelper.ts
@@ -55,7 +55,7 @@ export class DocumentTypeApiHelper {
     return elementType;
   }
 
-  async createDefaultDocumentWithBlockGridEditor(umbracoApi, element, dataType) {
+  async createDefaultDocumentWithBlockGridEditor(element, dataType) {
     const documentName = 'DocumentTest';
     const blockGridName = 'BlockGridTest';
     const elementName = 'ElementTest';
@@ -64,10 +64,10 @@ export class DocumentTypeApiHelper {
     const elementAlias = AliasHelper.toAlias(elementName);
 
     if (element == null) {
-      element = await umbracoApi.documentTypes.createDefaultElementType(elementName, elementAlias);
+      element = await this.api.documentTypes.createDefaultElementType(elementName, elementAlias);
     }
     if (dataType == null) {
-      dataType = await this.api.dataTypes.createDefaultBlockGrid(umbracoApi, blockGridName, element);
+      dataType = await this.api.dataTypes.createDefaultBlockGrid(blockGridName, element);
     }
 
     const docType = new DocumentTypeBuilder()
@@ -83,7 +83,7 @@ export class DocumentTypeApiHelper {
         .done()
       .done()
       .build();
-    await umbracoApi.documentTypes.save(docType);
+    await this.api.documentTypes.save(docType);
 
     return element;
   }


### PR DESCRIPTION
We added this.api instead of umbracoApi because there was no reason to use umbracoApi with the functions