### PR TITLE
V2 Updated helper to fix the failed acceptance tests

### DIFF
--- a/lib/helpers/LogViewerUiHelper.ts
+++ b/lib/helpers/LogViewerUiHelper.ts
@@ -1,0 +1,116 @@
+import {Page, Locator, expect} from "@playwright/test";
+import {UiBaseLocators} from "./UiBaseLocators";
+
+export class LogViewerUiHelper extends UiBaseLocators {
+  private readonly searchBtn: Locator;
+  private readonly searchLogsTxt: Locator;
+  private readonly selectLogLevelBtn: Locator;
+  private readonly saveSearchHeartIcon: Locator;
+  private readonly searchNameTxt: Locator;
+  private readonly saveSearchBtn: Locator;
+  private readonly overviewBtn: Locator;
+  private readonly sortLogByTimestampBtn: Locator;
+  private readonly firstLogLevelTimestamp: Locator;
+  private readonly firstLogLevelMessage: Locator;
+  private readonly pageTwoBtn: Locator;
+  private readonly firstLogSearchResult: Locator;
+  private readonly savedSearchesBtn: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.searchBtn = page.getByRole('tab', {name: 'Search'});
+    this.searchLogsTxt = page.getByPlaceholder('Search logs...');
+    this.selectLogLevelBtn = page.getByLabel('Select log levels');
+    this.saveSearchHeartIcon = page.getByLabel("Save search");
+    this.searchNameTxt = page.getByLabel("Search name");
+    this.saveSearchBtn = page.locator('uui-dialog-layout').getByLabel("Save search");
+    this.overviewBtn = page.getByRole('tab', {name: 'Overview'});
+    this.sortLogByTimestampBtn = page.getByLabel('Sort logs');
+    this.firstLogLevelTimestamp = page.locator('umb-log-viewer-message').locator('[id="timestamp"]').first();
+    this.firstLogLevelMessage = page.locator('umb-log-viewer-message').locator('[id="message"]').first();
+    this.pageTwoBtn = page.getByLabel('Go to page 2', {exact: true});
+    this.firstLogSearchResult =  page.getByRole('group').locator('#message').first();
+    this.savedSearchesBtn = page.getByLabel('Saved searches');
+  }
+
+  async clickSearchButton() {
+    await this.searchBtn.click({force: true});
+  }
+
+  async clickOverviewButton() {
+    await this.overviewBtn.click({force: true});
+  }
+
+  async enterSearchKeyword(keyword: string) {
+    await this.searchLogsTxt.clear();
+    await this.searchLogsTxt.fill(keyword);
+  }
+
+  async selectLogLevel(level: string) {
+    await this.selectLogLevelBtn.click({force: true});
+    await this.page.locator('.log-level-menu-item').getByText(level).click({force: true});
+  }
+
+  async doesLogLevelIndicatorDisplay(level: string) {
+    return await expect(this.page.locator('.log-level-button-indicator', {hasText: level})).toBeVisible();
+  }
+
+  async doesLogLevelCountMatch(level: string, expectedNumber: number) {
+    return await expect(this.page.locator('umb-log-viewer-message').locator('umb-log-viewer-level-tag', {hasText: level})).toHaveCount(expectedNumber);
+  }
+
+  async saveSearch(searchName: string) {
+    await this.saveSearchHeartIcon.click({force: true});
+    await this.searchNameTxt.clear();
+    await this.searchNameTxt.fill(searchName);
+    await this.saveSearchBtn.click();
+  }
+
+  async doesSavedSearchDisplay(searchName: string) {
+    return await expect(this.page.locator('#saved-searches').getByLabel(searchName, {exact: true})).toBeVisible();
+  }
+
+  async doesSavedSearchNotDisplay(searchName: string) {
+    return await expect(this.page.locator('#saved-searches').getByLabel(searchName, {exact: true})).not.toBeVisible();
+  }
+
+  async clickSortLogByTimestampButton() {
+    await this.sortLogByTimestampBtn.click();
+  }
+
+  async doesFirstLogHasTimestamp(timestamp: string) {
+    return await expect(this.firstLogLevelTimestamp).toContainText(timestamp);
+  }
+
+  async clickPageTwo() {
+    await this.pageTwoBtn.click({force: true});
+  }
+
+  async doesFirstLogHasMessage(message: string) {
+    return await expect(this.firstLogLevelMessage).toContainText(message);
+  }
+
+  async clickSavedSearchByName(name: string) {
+    await this.page.locator('#saved-searches').getByLabel(name).click();
+  }
+
+  async doesSearchBoxHasValue(searchValue: string) {
+    await expect(this.page.getByPlaceholder('Search logs...')).toHaveValue(searchValue);
+  }
+
+  async clickFirstLogSearchResult() {
+    await this.firstLogSearchResult.click();
+  }
+
+  async doesDetailedLogHasText(text: string) {
+    return await expect(this.page.locator('details[open] .property-value').getByText(text)).toBeVisible();
+  }
+
+  async clickSavedSearchesButton() {
+    await this.savedSearchesBtn.click({force: true});
+  }
+
+  async removeSavedSearchByName(name: string) {
+    await this.page.locator('li').filter({hasText: name}).getByLabel('Remove saved search').click({force: true});
+  }
+}

--- a/lib/helpers/LogViewerUiHelper.ts
+++ b/lib/helpers/LogViewerUiHelper.ts
@@ -12,7 +12,6 @@ export class LogViewerUiHelper extends UiBaseLocators {
   private readonly sortLogByTimestampBtn: Locator;
   private readonly firstLogLevelTimestamp: Locator;
   private readonly firstLogLevelMessage: Locator;
-  private readonly pageTwoBtn: Locator;
   private readonly firstLogSearchResult: Locator;
   private readonly savedSearchesBtn: Locator;
 
@@ -28,7 +27,6 @@ export class LogViewerUiHelper extends UiBaseLocators {
     this.sortLogByTimestampBtn = page.getByLabel('Sort logs');
     this.firstLogLevelTimestamp = page.locator('umb-log-viewer-message').locator('[id="timestamp"]').first();
     this.firstLogLevelMessage = page.locator('umb-log-viewer-message').locator('[id="message"]').first();
-    this.pageTwoBtn = page.getByLabel('Go to page 2', {exact: true});
     this.firstLogSearchResult =  page.getByRole('group').locator('#message').first();
     this.savedSearchesBtn = page.getByLabel('Saved searches');
   }
@@ -66,27 +64,23 @@ export class LogViewerUiHelper extends UiBaseLocators {
     await this.saveSearchBtn.click();
   }
 
-  async doesSavedSearchDisplay(searchName: string) {
-    return await expect(this.page.locator('#saved-searches').getByLabel(searchName, {exact: true})).toBeVisible();
-  }
-
-  async doesSavedSearchNotDisplay(searchName: string) {
-    return await expect(this.page.locator('#saved-searches').getByLabel(searchName, {exact: true})).not.toBeVisible();
+  checkSavedSearch(searchName: string) {
+    return this.page.locator('#saved-searches').getByLabel(searchName, {exact: true});
   }
 
   async clickSortLogByTimestampButton() {
     await this.sortLogByTimestampBtn.click();
   }
 
-  async doesFirstLogHasTimestamp(timestamp: string) {
+  async doesFirstLogHaveTimestamp(timestamp: string) {
     return await expect(this.firstLogLevelTimestamp).toContainText(timestamp);
   }
 
-  async clickPageTwo() {
-    await this.pageTwoBtn.click({force: true});
+  async clickPageNumber(pageNumber: number) {
+    await this.page.getByLabel('Go to page ' + pageNumber, {exact: true}).click();
   }
 
-  async doesFirstLogHasMessage(message: string) {
+  async doesFirstLogHaveMessage(message: string) {
     return await expect(this.firstLogLevelMessage).toContainText(message);
   }
 
@@ -94,7 +88,7 @@ export class LogViewerUiHelper extends UiBaseLocators {
     await this.page.locator('#saved-searches').getByLabel(name).click();
   }
 
-  async doesSearchBoxHasValue(searchValue: string) {
+  async doesSearchBoxHaveValue(searchValue: string) {
     await expect(this.page.getByPlaceholder('Search logs...')).toHaveValue(searchValue);
   }
 
@@ -102,7 +96,7 @@ export class LogViewerUiHelper extends UiBaseLocators {
     await this.firstLogSearchResult.click();
   }
 
-  async doesDetailedLogHasText(text: string) {
+  async doesDetailedLogHaveText(text: string) {
     return await expect(this.page.locator('details[open] .property-value').getByText(text)).toBeVisible();
   }
 

--- a/lib/helpers/LoginUiHelper.ts
+++ b/lib/helpers/LoginUiHelper.ts
@@ -1,0 +1,29 @@
+import {Page, Locator} from "@playwright/test";
+import {UiBaseLocators} from "./UiBaseLocators";
+
+export class LoginUiHelper extends UiBaseLocators {
+  private readonly emailTxt: Locator;
+  private readonly passwordTxt: Locator;
+  private readonly loginBtn: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.emailTxt = page.getByLabel('Email');
+    this.passwordTxt = page.getByLabel('Password', { exact: true });
+    this.loginBtn = page.getByLabel('Login'); 
+  }
+
+  async enterEmail(email: string) {
+    await this.emailTxt.clear();
+    await this.emailTxt.fill(email);
+  }
+
+  async enterPassword(password: string) {
+    await this.passwordTxt.clear();
+    await this.passwordTxt.fill(password);
+  }
+
+  async clickLoginButton() {
+    await this.loginBtn.click();
+  }
+}

--- a/lib/helpers/PartialViewApiHelper.ts
+++ b/lib/helpers/PartialViewApiHelper.ts
@@ -150,23 +150,10 @@ export class PartialViewApiHelper {
         "name": name,
         "parentPath": parentPath
       };
-    const response = await this.api.post(this.api.baseUrl + '/umbraco/management/api/v1/partial-view/folder', partialViewFolderData);
-    // Returns the id of the created partialViewFolder
-    const json = await response.json();
-    return json.path;
+    return await this.api.post(this.api.baseUrl + '/umbraco/management/api/v1/partial-view/folder', partialViewFolderData);
   }
 
   async deleteFolder(path: string) {
     return await this.api.delete(this.api.baseUrl + '/umbraco/management/api/v1/partial-view/folder?path=' + path);
-  }
-
-  async getFolderChildren(path: string) {
-    const response = await this.api.get(this.api.baseUrl + '/umbraco/management/api/v1/tree/partial-view/children?path=' + path + '&skip=0&take=10000');
-    const json = await response.json();
-
-    if (json !== null) {
-      return json;
-    }
-    return null;
   }
 }

--- a/lib/helpers/ScriptApiHelper.ts
+++ b/lib/helpers/ScriptApiHelper.ts
@@ -172,10 +172,7 @@ export class ScriptApiHelper {
         "name": name,
         "parentPath": parentPath
       };
-    const response = await this.api.post(this.api.baseUrl + '/umbraco/management/api/v1/script/folder', scriptFolderData);
-    // Returns the path of the created scriptFolder
-    const json = await response.json();
-    return json.path;
+    return await this.api.post(this.api.baseUrl + '/umbraco/management/api/v1/script/folder', scriptFolderData);
   }
 
   async deleteFolder(path: string) {

--- a/lib/helpers/StylesheetApiHelper.ts
+++ b/lib/helpers/StylesheetApiHelper.ts
@@ -162,10 +162,7 @@ export class StylesheetApiHelper {
         "name": name,
         "parentPath": parentPath
       };
-    const response = await this.api.post(this.api.baseUrl + '/umbraco/management/api/v1/stylesheet/folder', stylesheetFolderData);
-    // Returns the id of the created stylesheetFolder
-    const json = await response.json();
-    return json.path;
+    return await this.api.post(this.api.baseUrl + '/umbraco/management/api/v1/stylesheet/folder', stylesheetFolderData);
   }
 
   async deleteFolder(path: string) {

--- a/lib/helpers/TelemetryDataUiHelper.ts
+++ b/lib/helpers/TelemetryDataUiHelper.ts
@@ -19,7 +19,7 @@ export class TelemetryDataUiHelper extends UiBaseLocators {
     await this.telemetryDataLevelSlider.fill(value);
   }
 
-  async doesTelemetryDataLevelHasValue(value: string) {
+  async doesTelemetryDataLevelHaveValue(value: string) {
     return await expect(this.telemetryDataLevelSlider).toHaveValue(value);
   }
 }

--- a/lib/helpers/TelemetryDataUiHelper.ts
+++ b/lib/helpers/TelemetryDataUiHelper.ts
@@ -1,0 +1,25 @@
+import {Page, Locator, expect} from "@playwright/test";
+import {UiBaseLocators} from "./UiBaseLocators";
+
+export class TelemetryDataUiHelper extends UiBaseLocators {
+  private readonly telemetryDataTab: Locator;
+  private readonly telemetryDataLevelSlider: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.telemetryDataTab = page.getByRole('tab', {name: 'Telemetry Data'});
+    this.telemetryDataLevelSlider = page.locator('[name="telemetryLevel"] >> input[id=input]');
+  }
+
+  async clickTelemetryDataTab() {
+    await this.telemetryDataTab.click();
+  }
+
+  async changeTelemetryDataLevelValue(value: string) {
+    await this.telemetryDataLevelSlider.fill(value);
+  }
+
+  async doesTelemetryDataLevelHasValue(value: string) {
+    return await expect(this.telemetryDataLevelSlider).toHaveValue(value);
+  }
+}

--- a/lib/helpers/UiBaseLocators.ts
+++ b/lib/helpers/UiBaseLocators.ts
@@ -39,7 +39,7 @@ export class UiBaseLocators {
     this.modalCaretBtn = page.locator('umb-tree-picker-modal').locator('#caret-button');
     this.queryBuilderBtn = page.locator('#query-builder-button').getByLabel('Query builder')
     this.queryBuilderOrderedBy = page.locator('#property-alias-dropdown').getByLabel('Property alias');
-    this.queryBuilderCreateDate = page.locator('#property-alias-dropdown').getByText('CreateDate');
+    this.queryBuilderCreateDate = page.locator('#property-alias-dropdown').getByText('CreateDate').locator("..");
     this.folderNameTxt = page.getByRole('textbox', {name: 'Enter folder name...'});
     this.textAreaInputArea = page.locator('textarea.inputarea');
   }

--- a/lib/helpers/UiHelpers.ts
+++ b/lib/helpers/UiHelpers.ts
@@ -5,6 +5,9 @@ import {PartialViewUiHelper} from "./PartialViewUiHelper";
 import {ScriptUiHelper} from "./ScriptUiHelper";
 import {TemplateUiHelper} from "./TemplateUiHelper";
 import {DictionaryUiHelper} from "./DictionaryUiHelper";
+import {LoginUiHelper} from "./LoginUiHelper";
+import {LogViewerUiHelper} from "./LogViewerUiHelper";
+import {TelemetryDataUiHelper} from "./TelemetryDataUiHelper";
 
 export class UiHelpers {
   page: Page;
@@ -13,6 +16,9 @@ export class UiHelpers {
   dictionary: DictionaryUiHelper;
   script: ScriptUiHelper;
   template: TemplateUiHelper;
+  login: LoginUiHelper;
+  logViewer: LogViewerUiHelper;
+  telemetryData: TelemetryDataUiHelper;
 
   constructor(page: Page) {
     this.page = page;
@@ -21,6 +27,9 @@ export class UiHelpers {
     this.script = new ScriptUiHelper(this.page);
     this.template = new TemplateUiHelper(this.page);
     this.dictionary = new DictionaryUiHelper(this.page);
+    this.login = new LoginUiHelper(this.page);
+    this.logViewer = new LogViewerUiHelper(this.page);
+    this.telemetryData = new TelemetryDataUiHelper(this.page);
   }
 
   async goToBackOffice() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco/playwright-testhelpers",
-      "version": "2.0.0-beta.10",
+      "version": "2.0.0-beta.11",
       "license": "MIT",
       "dependencies": {
         "@umbraco/json-models-builders": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "description": "Test helpers for making playwright tests for Umbraco solutions",
   "main": "dist/lib/index.js",
   "files": ["dist/**/*"],


### PR DESCRIPTION
This PR focuses on fixing issues that broke our tests after changes were made to the new backoffice. It includes:

- Added Ui helpers for Login page, Telemetry Data page and LogViewer page
- Updated api helpers for Stylesheet, Script and Partial view as response of create folder api was changed
- Updated UiBaseLocators to fix the method addQueryBuilderWithCreateDateOption()
- Bumped version

### Test
Go into the file README.md and find the section for 'Testing your changes locally'
Run the NewBackOffice in v14/dev.
Test if the helpers function as expected by creating simple tests using the helpers