### PR TITLE
Fixed local storage auth token being retrieved incorrectly

### DIFF
--- a/lib/helpers/ApiHelpers.ts
+++ b/lib/helpers/ApiHelpers.ts
@@ -104,9 +104,8 @@ export class ApiHelpers {
   }
 
   async getAccessToken() {
-    let someStorage = await this.page.context().storageState();
-    let someObject = JSON.parse(someStorage.origins[0].localStorage[0].value);
-    return someObject.access_token;
+    const authToken = await this.getLocalStorageAuthToken();
+    return authToken.access_token;
   }
 
   async getBearerToken() {
@@ -189,21 +188,18 @@ export class ApiHelpers {
   }
 
   private async getTokenIssuedTime() {
-    let someStorage = await this.page.context().storageState();
-    let someObject = JSON.parse(someStorage.origins[0].localStorage[0].value);
-    return Number(someObject.issued_at);
+    const authToken = await this.getLocalStorageAuthToken();
+    return Number(authToken.issued_at);
   }
 
   private async getTokenExpireTime() {
-    let someStorage = await this.page.context().storageState();
-    let someObject = JSON.parse(someStorage.origins[0].localStorage[0].value);
-    return Number(someObject.expires_in);
+    const authToken = await this.getLocalStorageAuthToken();
+    return Number(authToken.expires_in);
   }
 
   async getRefreshToken() {
-    let someStorage = await this.page.context().storageState();
-    let someObject = JSON.parse(someStorage.origins[0].localStorage[0].value);
-    return await someObject.refresh_token;
+    const authToken = await this.getLocalStorageAuthToken();
+    return await authToken.refresh_token;
   }
 
   async isAccessTokenValid() {
@@ -317,12 +313,15 @@ export class ApiHelpers {
     return await localStorage.origins?.[0]?.localStorage?.find(item => item.name === tokenName);
   }
 
-  private async updateLocalStorage(localStorageValue) {
+  private async getLocalStorageAuthToken(){
     const currentStorageState = await this.page.context().storageState();
     const currentStorageToken = await this.getLocalStorageToken(currentStorageState, 'umb:userAuthTokenResponse');
+    return JSON.parse(currentStorageToken.value);
+  }
 
+  private async updateLocalStorage(localStorageValue) {
     // Parse the existing token value and update its fields
-    let currentLocalStorageValue = JSON.parse(currentStorageToken.value);
+    let currentLocalStorageValue = await this.getLocalStorageAuthToken();
     const newIssuedTime = await this.currentDateToEpoch();
 
     currentLocalStorageValue.access_token = localStorageValue.access_token;


### PR DESCRIPTION
I've been using these helpers in the integration tests of my package.
When I was testing V15 locally, I kept getting this error:
```
SyntaxError: Unexpected non-whitespace character after JSON at position 4

    at ApiHelpers.getRefreshToken (D:\Projects\Umbraco.Community.DeliveryApiExtensions\tests\UmbracoDeliveryApiExtensions.Playwright\node_modules\@umbraco\playwright-testhelpers\lib\helpers\ApiHelpers.ts:205:27)
    at ApiHelpers.refreshAccessToken (D:\Projects\Umbraco.Community.DeliveryApiExtensions\tests\UmbracoDeliveryApiExtensions.Playwright\node_modules\@umbraco\playwright-testhelpers\lib\helpers\ApiHelpers.ts:250:26)
    at Object.umbracoApi (D:\Projects\Umbraco.Community.DeliveryApiExtensions\tests\UmbracoDeliveryApiExtensions.Playwright\node_modules\@umbraco\playwright-testhelpers\lib\helpers\testExtension.ts:11:5)
```

When I checked the `ApiHelpers` code, I noticed that several calls were assuming that the auth token would be in index 0 of `origins`, which wasn't the case for me:
```
{
  ...
  "origins": [
    {
      "origin": "https://localhost:44363",
      "localStorage": [
        {
          "name": "umb:serverUpgradeCheck",
          "value": "{\"type\":\"None\",\"comment\":\"\",\"url\":\"\",\"expires\":\"2024-11-22T21:02:48.808Z\"}"
        },
        {
          "name": "umb:lastUpgradeCheck",
          "value": "2024-11-15T21:02:48.436Z"
        },
        {
          "name": "umb:userAuthTokenResponse",
          "value": "{\"access_token\":\"...\",\"scope\":\"offline_access\",\"token_type\":\"Bearer\",\"issued_at\":1731704598,\"expires_in\":\"3600\"}"
        }
      ]
    }
  ]
}
```

This fixes #160.