### PR TITLE
V16: Update Stylesheet Create button locator

### DIFF
--- a/lib/helpers/StylesheetUiHelper.ts
+++ b/lib/helpers/StylesheetUiHelper.ts
@@ -20,7 +20,7 @@ export class StylesheetUiHelper extends UiBaseLocators{
     this.styleNameTxt = page.getByLabel('Rule name');
     this.styleSelectorTxt = page.getByLabel('Rule selector');
     this.styleStylesTxt = page.getByLabel('Rule styles');
-    this.newStylesheetBtn = page.getByLabel('New Stylesheet');
+    this.newStylesheetBtn = this.createOptionActionListModal.locator('[name="New Stylesheet"]');
     this.newRichTextEditorStylesheetBtn = page.getByLabel('New Rich Text Editor Stylesheet');
     this.stylesheetTree = page.locator('umb-tree[alias="Umb.Tree.Stylesheet"]');
     this.newFolderThreeDots = page.getByLabel('New Folder...');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "15.0.43",
+  "version": "16.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco/playwright-testhelpers",
-      "version": "15.0.43",
+      "version": "16.0.0",
       "license": "MIT",
       "dependencies": {
         "@umbraco/json-models-builders": "2.0.31",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "15.0.43",
+  "version": "16.0.0",
   "description": "Test helpers for making playwright tests for Umbraco solutions",
   "main": "dist/lib/index.js",
   "files": [


### PR DESCRIPTION
With updates made in https://github.com/umbraco/Umbraco-CMS/pull/18911, the acceptance tests were failing.

I needed to update the locator for "New Stylesheet" button, making use of the `createOptionActionListModal` locator in the base class, to align with Data Type and Media Type create option actions modal.

> [!NOTE]
> I have incremented the version number to 16.0.0, to align with the Umbraco CMS version, and set the target branch to be `v16/dev`. The reason for this is that the Stylesheets Create Options markup have not changed in Umbraco CMS v15.x, so the acceptance tests need to target the v16 helper library. 