### PR TITLE
V16: Update Stylesheet folder button reference

### DIFF
--- a/lib/helpers/StylesheetUiHelper.ts
+++ b/lib/helpers/StylesheetUiHelper.ts
@@ -6,14 +6,12 @@ export class StylesheetUiHelper extends UiBaseLocators{
   private readonly newStylesheetBtn: Locator;
   private readonly stylesheetNameTxt: Locator;
   private readonly stylesheetTree: Locator;
-  private readonly newFolderThreeDots: Locator;
 
   constructor(page: Page) {
     super(page);
     this.stylesheetNameTxt = page.locator('umb-stylesheet-workspace-editor').locator('#nameInput #input');
     this.newStylesheetBtn = this.createOptionActionListModal.locator('[name="New Stylesheet"]');
     this.stylesheetTree = page.locator('umb-tree[alias="Umb.Tree.Stylesheet"]');
-    this.newFolderThreeDots = page.getByLabel('New Folder...');
   }
 
   async clickActionsMenuForStylesheet(name: string) {
@@ -22,7 +20,7 @@ export class StylesheetUiHelper extends UiBaseLocators{
 
   async createStylesheetFolder(folderName: string) {
     await this.clickActionsMenuCreateButton();
-    await this.newFolderThreeDots.click();
+    await this.clickFolderButton();
     await this.enterFolderName(folderName);
     await this.clickConfirmCreateFolderButton();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco/playwright-testhelpers",
-      "version": "16.0.0",
+      "version": "16.0.1",
       "license": "MIT",
       "dependencies": {
         "@umbraco/json-models-builders": "2.0.31",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "description": "Test helpers for making playwright tests for Umbraco solutions",
   "main": "dist/lib/index.js",
   "files": [


### PR DESCRIPTION
Another fix for https://github.com/umbraco/Umbraco-CMS/pull/18911, the locator for the create folder action had changed, so have updated to use the `.clickFolderButton()` method in the base class, (this aligns with Data Type, Media Type, etc).

Bumped version number to v16.0.1.