### PR TITLE
V16: Updates localized text label locators ("New Data Type" and "Change your password")

### DIFF
--- a/lib/helpers/DataTypeUiHelper.ts
+++ b/lib/helpers/DataTypeUiHelper.ts
@@ -298,7 +298,7 @@ export class DataTypeUiHelper extends UiBaseLocators {
     this.tiptapExtensionsConfiguration = this.page.locator('umb-property-editor-ui-tiptap-extensions-configuration');
     this.propertyEditor = this.page.locator('umb-ref-property-editor-ui');
     this.selectIconBtn = page.getByLabel('Select icon');
-    this.dataTypeBtn = this.createOptionActionListModal.locator('[name="Data Type"]');
+    this.dataTypeBtn = this.createOptionActionListModal.locator('[name="New Data Type"]');
     this.dataTypesMenu = page.locator('#menu-item').getByRole('link', {name: 'Data Types'});
     this.tiptapStatusbarConfiguration = this.page.locator('umb-property-editor-ui-tiptap-statusbar-configuration');
 

--- a/lib/helpers/UserUiHelper.ts
+++ b/lib/helpers/UserUiHelper.ts
@@ -46,7 +46,7 @@ export class UserUiHelper extends UiBaseLocators {
     this.openUserGroupsBtn = page.locator('[label="Groups"]').getByLabel('open', {exact: true});
     this.chooseUserGroupsBtn = page.locator('umb-user-group-input').getByLabel('Choose');
     this.updatedNameOfTheUserTxt = page.locator('umb-workspace-header-name-editable').locator('input');
-    this.changePasswordBtn = page.getByLabel('Change password');
+    this.changePasswordBtn = page.getByLabel('Change your password');
     this.changePhotoBtn = page.getByLabel('Change photo');
     this.removePhotoBtn = page.getByLabel('Remove photo');
     this.searchInUserSectionTxt = page.locator('umb-collection-filter-field #input');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "16.0.10",
+  "version": "16.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco/playwright-testhelpers",
-      "version": "16.0.10",
+      "version": "16.0.11",
       "license": "MIT",
       "dependencies": {
         "@umbraco/json-models-builders": "2.0.33",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "16.0.10",
+  "version": "16.0.11",
   "description": "Test helpers for making playwright tests for Umbraco solutions",
   "main": "dist/lib/index.js",
   "files": [


### PR DESCRIPTION
With updates made to the localization files in https://github.com/umbraco/Umbraco-CMS/pull/19258, the acceptance tests were failing.

I needed to update the locator for "New Data Type" and "Change your password" buttons.

I have bumped the version number to v16.0.11.