### PR TITLE
V16 updates for caret button

### DIFF
--- a/lib/helpers/ContentUiHelper.ts
+++ b/lib/helpers/ContentUiHelper.ts
@@ -393,6 +393,15 @@ export class ContentUiHelper extends UiBaseLocators {
     await this.clickActionsMenuForName(name);
   }
 
+  async openContentCaretButtonForName(name: string) {
+    const menuItem = this.menuItemTree.filter({hasText: name}).last()
+    const isCaretButtonOpen = await menuItem.getAttribute('show-children');
+
+    if (isCaretButtonOpen === null) {
+      await this.clickCaretButtonForContentName(name);
+    }
+  }
+
   async clickCaretButtonForContentName(name: string) {
     await expect(this.menuItemTree.filter({hasText: name}).last().locator('#caret-button').last()).toBeVisible();
     await this.menuItemTree.filter({hasText: name}).last().locator('#caret-button').last().click();
@@ -930,7 +939,7 @@ export class ContentUiHelper extends UiBaseLocators {
   }
 
   async selectDocumentWithNameAtRoot(name: string) {
-    await this.clickCaretButtonForName('Content');
+    await this.openCaretButtonForName('Content');
     const documentWithNameLocator = this.modalContent.getByLabel(name);
     await expect(documentWithNameLocator).toBeVisible();
     await documentWithNameLocator.click();

--- a/lib/helpers/DataTypeUiHelper.ts
+++ b/lib/helpers/DataTypeUiHelper.ts
@@ -322,7 +322,7 @@ export class DataTypeUiHelper extends UiBaseLocators {
   }
 
   async clickRootFolderCaretButton() {
-    await this.clickCaretButtonForName('Data Types');
+    await this.openCaretButtonForName('Data Types');
   }
 
   async createDataTypeFolder(folderName: string) {
@@ -995,8 +995,8 @@ export class DataTypeUiHelper extends UiBaseLocators {
   async chooseBlockCustomStylesheetWithName(name: string) {
     await expect(this.chooseCustomStylesheetBtn).toBeVisible();
     await this.chooseCustomStylesheetBtn.click();
-    await this.clickCaretButtonForName('wwwroot');
-    await this.clickCaretButtonForName('css');
+    await this.openCaretButtonForName('wwwroot');
+    await this.openCaretButtonForName('css');
     await this.clickLabelWithName(name, true);
     await this.clickChooseModalButton();
   }
@@ -1005,7 +1005,7 @@ export class DataTypeUiHelper extends UiBaseLocators {
     const mediaItems = mediaPath.split('/media/')[1].split('/');
     await expect(this.chooseThumbnailAlias).toBeVisible();
     await this.chooseThumbnailAlias.click();
-    await this.clickCaretButtonForName('wwwroot');
+    await this.openCaretButtonForName('wwwroot');
     await this.clickExpandChildItemsForMediaButton();
     for (let i = 0; i < mediaItems.length; i++) {
       if (i === mediaItems.length - 1) {

--- a/lib/helpers/DocumentBlueprintUiHelper.ts
+++ b/lib/helpers/DocumentBlueprintUiHelper.ts
@@ -23,7 +23,7 @@ export class DocumentBlueprintUiHelper extends UiBaseLocators{
   }
 
   async clickRootFolderCaretButton() {
-    await this.clickCaretButtonForName('Document Blueprints');
+    await this.openCaretButtonForName('Document Blueprints');
   }
 
   async waitForDocumentBlueprintToBeCreated() {

--- a/lib/helpers/DocumentTypeUiHelper.ts
+++ b/lib/helpers/DocumentTypeUiHelper.ts
@@ -44,7 +44,7 @@ export class DocumentTypeUiHelper extends UiBaseLocators {
   }
 
   async clickRootFolderCaretButton() {
-    await this.clickCaretButtonForName("Document Types");
+    await this.openCaretButtonForName('Document Types');
   }
 
   async clickNewDocumentTypeButton() {

--- a/lib/helpers/MediaTypeUiHelper.ts
+++ b/lib/helpers/MediaTypeUiHelper.ts
@@ -26,7 +26,7 @@ export class MediaTypeUiHelper extends UiBaseLocators {
   }
 
   async clickRootFolderCaretButton() {
-    await this.clickCaretButtonForName("Media Types");
+    await this.openCaretButtonForName("Media Types");
   }
 
   async clickNewMediaTypeButton() {

--- a/lib/helpers/MediaUiHelper.ts
+++ b/lib/helpers/MediaUiHelper.ts
@@ -145,6 +145,15 @@ export class MediaUiHelper extends UiBaseLocators {
     await this.page.locator('umb-media-tree-item [label="' + name + '"]').locator('#caret-button').click();
   }
 
+  async openMediaCaretButtonForName(name: string) {
+    const menuItem = this.page.locator('umb-media-tree-item [label="' + name + '"]')
+    const isCaretButtonOpen = await menuItem.getAttribute('show-children');
+
+    if (isCaretButtonOpen === null) {
+      await this.clickMediaCaretButtonForName(name);
+    }
+  }
+  
   async doesMediaGridValuesMatch(expectedValues: string[]) {
     return expectedValues.forEach((text, index) => {
       expect(this.mediaCardItemsValues.nth(index)).toHaveText(text);

--- a/lib/helpers/MemberTypeUiHelper.ts
+++ b/lib/helpers/MemberTypeUiHelper.ts
@@ -20,7 +20,7 @@ export class MemberTypeUiHelper extends UiBaseLocators {
   }
 
   async clickRootFolderCaretButton() {
-    await this.clickCaretButtonForName("Member Types");
+    await this.openCaretButtonForName("Member Types");
   }
 
   async goToMemberType(memberTypeName: string) {

--- a/lib/helpers/PartialViewUiHelper.ts
+++ b/lib/helpers/PartialViewUiHelper.ts
@@ -26,7 +26,7 @@ export class PartialViewUiHelper extends UiBaseLocators {
   }
 
   async clickRootFolderCaretButton() {
-    await this.clickCaretButtonForName('Partial Views');
+    await this.openCaretButtonForName('Partial Views');
   }
 
   async waitForPartialViewToBeCreated() {

--- a/lib/helpers/RelationTypeUiHelper.ts
+++ b/lib/helpers/RelationTypeUiHelper.ts
@@ -43,7 +43,7 @@ export class RelationTypeUiHelper extends UiBaseLocators{
   }
 
   async clickRootFolderCaretButton() {
-    await this.clickCaretButtonForName("Relation Types");
+    await this.openCaretButtonForName("Relation Types");
   }
 
   async clickActionsMenuAtRoot() {

--- a/lib/helpers/ScriptUiHelper.ts
+++ b/lib/helpers/ScriptUiHelper.ts
@@ -30,7 +30,7 @@ export class ScriptUiHelper extends UiBaseLocators{
   }
 
   async clickRootFolderCaretButton() {
-    await this.clickCaretButtonForName('Scripts');
+    await this.openCaretButtonForName('Scripts');
   }
 
   async clickNewJavascriptFileButton() {

--- a/lib/helpers/StylesheetUiHelper.ts
+++ b/lib/helpers/StylesheetUiHelper.ts
@@ -30,7 +30,7 @@ export class StylesheetUiHelper extends UiBaseLocators{
   }
 
   async clickRootFolderCaretButton() {
-    await this.clickCaretButtonForName('Stylesheets');
+    await this.openCaretButtonForName('Stylesheets');
   }
 
   async clickNewStylesheetButton() {

--- a/lib/helpers/TemplateUiHelper.ts
+++ b/lib/helpers/TemplateUiHelper.ts
@@ -27,7 +27,7 @@ export class TemplateUiHelper extends UiBaseLocators {
   }
 
   async clickRootFolderCaretButton() {
-    await this.clickCaretButtonForName('Templates');
+    await this.openCaretButtonForName('Templates');
   }
 
   async waitForTemplateToBeCreated() {
@@ -49,7 +49,7 @@ export class TemplateUiHelper extends UiBaseLocators {
       await this.page.getByLabel(templateName, {exact: true}).click();
       await expect(this.enterAName).toHaveValue(templateName);
     } else {
-      await this.clickCaretButtonForName(templateName);
+      await this.openCaretButtonForName(templateName);
       await this.page.getByLabel(childTemplateName , {exact: true}).click();
       await expect(this.enterAName).toHaveValue(childTemplateName);
     }

--- a/lib/helpers/UiBaseLocators.ts
+++ b/lib/helpers/UiBaseLocators.ts
@@ -303,8 +303,8 @@ export class UiBaseLocators {
   }
 
   async clickActionsMenuForName(name: string) {
-    await expect(this.page.locator('uui-menu-item[label="' + name + '"]')).toBeVisible();
-    await this.page.locator('uui-menu-item[label="' + name + '"]').hover();
+    await expect(this.page.locator('uui-menu-item[label="' + name + '"]').locator('#menu-item').first()).toBeVisible();
+    await this.page.locator('uui-menu-item[label="' + name + '"]').locator('#menu-item').first().hover({force: true});
     await this.page.locator('uui-menu-item[label="' + name + '"] #action-modal').first().click({force: true});
   }
 
@@ -315,15 +315,24 @@ export class UiBaseLocators {
 
   async clickCaretButtonForName(name: string) {
     await this.isCaretButtonWithNameVisible(name);
-    await this.page.locator('div').filter({hasText: name}).locator('#caret-button').click();
+    await this.page.locator('uui-menu-item[label="' + name + '"]').locator('#caret-button').first().click();
   }
 
   async isCaretButtonWithNameVisible(name: string, isVisible = true) {
-    await expect(this.page.locator('div').filter({hasText: name}).locator('#caret-button')).toBeVisible({visible: isVisible});
+    await expect(this.page.locator('uui-menu-item[label="' + name + '"]').locator('#caret-button').first()).toBeVisible({visible: isVisible});
   }
 
   async clickCaretButton() {
     await this.page.locator('#caret-button').click();
+  }
+
+  async openCaretButtonForName(name: string) {
+    const menuItem = this.page.locator('uui-menu-item[label="' + name + '"]');
+    const isCaretButtonOpen = await menuItem.getAttribute('show-children');
+
+    if (isCaretButtonOpen === null) {
+      await this.clickCaretButtonForName(name);
+    }
   }
 
   async reloadTree(treeName: string) {
@@ -333,13 +342,7 @@ export class UiBaseLocators {
     await this.clickActionsMenuForName(treeName);
     await this.clickReloadChildrenActionMenuOption();
 
-    const menuItem = this.page.locator('uui-menu-item[label="' + treeName + '"]');
-    const isCaretButtonOpen = await menuItem.getAttribute('show-children');
-
-    if (isCaretButtonOpen === null) {
-      // We need to wait before clicking the caret button. Because the reload might not have happend yet. 
-      await this.clickCaretButtonForName(treeName);
-    }
+    await this.openCaretButtonForName(treeName);
   }
 
   async clickReloadButton() {
@@ -486,7 +489,7 @@ export class UiBaseLocators {
   }
 
   async clickRemoveExactButton() {
-  await expect(this.removeExactBtn).toBeVisible();
+    await expect(this.removeExactBtn).toBeVisible();
     await this.removeExactBtn.click();
   }
 
@@ -1053,14 +1056,8 @@ export class UiBaseLocators {
 
     await this.clickActionsMenuForName('Recycle Bin');
     await this.clickReloadChildrenActionMenuOption();
-    await expect(this.recycleBinMenuItem).toBeVisible();
-
-    await expect(this.recycleBinMenuItemCaretBtn.first()).toBeVisible();
-    const isCaretButtonOpen = await this.recycleBinMenuItem.first().getAttribute('show-children');
-
-    if (isCaretButtonOpen === null) {
-      await this.clickCaretButtonForName('Recycle Bin');
-    }
+    
+    await this.openCaretButtonForName('Recycle Bin');
   }
 
   async clickRecycleBinButton() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "16.0.34",
+  "version": "16.0.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco/playwright-testhelpers",
-      "version": "16.0.34",
+      "version": "16.0.35",
       "license": "MIT",
       "dependencies": {
         "@umbraco/json-models-builders": "2.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "16.0.34",
+  "version": "16.0.35",
   "description": "Test helpers for making playwright tests for Umbraco solutions",
   "main": "dist/lib/index.js",
   "files": [


### PR DESCRIPTION
There has been an update where the caret buttons expand when a child node is created. This broke the way we handle the "clicking" of the caret button. 

This PR adds a check to see if the caret button is already expanded; if so, we do not need to take further action.