### PR TITLE
V17 Deprecate package. the helpers and builders moved to Umbraco CMS repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# ⚠️ DEPRECATED
+
+This package has been deprecated. The helpers have been moved into the Umbraco CMS acceptance test project.
+
+**Please use [`@umbraco-cms/acceptance-test-helpers`](https://www.npmjs.com/package/@umbraco-cms/acceptance-test-helpers) instead.**
+
+```bash
+npm install @umbraco-cms/acceptance-test-helpers
+```
+
+---
+
 # Umbraco Playwright Test Helpers
 
 Test helpers for writing Playwright end-to-end tests for Umbraco CMS.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "17.0.37",
+  "version": "17.0.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umbraco/playwright-testhelpers",
-      "version": "17.0.37",
+      "version": "17.0.38",
       "license": "MIT",
       "dependencies": {
         "@umbraco/json-models-builders": "2.0.45",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@umbraco/playwright-testhelpers",
-  "version": "17.0.37",
-  "description": "Test helpers for making playwright tests for Umbraco solutions",
+  "version": "17.0.38",
+  "description": "DEPRECATED - Use @umbraco-cms/acceptance-test-helpers instead. Test helpers for making playwright tests for Umbraco solutions",
   "main": "dist/lib/index.js",
   "files": [
     "dist/**/*"


### PR DESCRIPTION
- The helpers and builders have been moved into the
  https://github.com/umbraco/Umbraco-CMS/tree/main/tests/Umbraco.Tests.AcceptanceTest
  - The new package is https://www.npmjs.com/package/@umbraco-cms/acceptance-test-helpers
  - Updated README with deprecation notice and link to the new package
  - Updated package.json description with deprecation prefix